### PR TITLE
Load test spec at runtime rather than Docker image build time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,14 @@ services:
     environment:
       - CYPRESS_baseUrl=http://web
     command: npx cypress run
+    # mount the host directory e2e/cypress and the file e2e/cypress.json as
+    # volumes within the container
+    # this means that:
+    #  1. anything that Cypress writes to these folders (e.g., screenshots,
+    #     videos) appears also on the Docker host's filesystem
+    #  2. any change that the developer applies to Cypress files on the host
+    #     machine immediately takes effect within the e2e container (no docker
+    #     rebuild required).
     volumes:
       - ./e2e/cypress:/app/cypress
       - ./e2e/cypress.json:/app/cypress.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,6 @@ services:
     environment:
       - CYPRESS_baseUrl=http://web
     command: npx cypress run
+    volumes:
+      - ./e2e/cypress:/app/cypress
+      - ./e2e/cypress.json:/app/cypress.json

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -14,6 +14,3 @@ RUN npm ci
 # running this command separately from "cypress run" will also cache its result
 # to avoid verifying again when running the tests
 RUN npx cypress verify
-
-COPY cypress cypress
-COPY cypress.json .


### PR DESCRIPTION
If we copy cypress/ and cypress.json into the Docker container at image build time, then the user is forced to rebuild the entire image every time they want to modify their test and re-run Cypress. By loading the test specs as Docker volumes, the user can modify them and then re-run the tests without having to rebuild the image.

This also means that when the tests fail, the artifacts folders are available on the host machine rather than trapped in the Docker container.