### PR TITLE
Pass proxy information to cypress docker builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,12 @@ version: '3'
 services:
   web:
     image: apache
-    build: ./webapp
+    build: 
+      context: ./e2e
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     container_name: apache
     restart: always
     # we can see the server running at "localhost:8080"

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,4 +1,11 @@
 FROM cypress/base:10
+
+# Optionally pass proxy information to get internet connectivity within npm ci 
+# postinstall hooks when running behind corparate proxies.
+ARG http_proxy 
+ARG https_proxy
+ARG no_proxy
+
 WORKDIR /app
 
 # dependencies will be installed only if the package files change


### PR DESCRIPTION
Optionally pass proxy information to get internet connectivity within npm ci postinstall hooks when running behind corparate proxies.