### PR TITLE
Revert (#11)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,7 @@ version: '3'
 services:
   web:
     image: apache
-    build: 
-      context: ./e2e
-      args:
-        - http_proxy
-        - https_proxy
-        - no_proxy
+    build: ./webapp
     container_name: apache
     restart: always
     # we can see the server running at "localhost:8080"

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,11 +1,4 @@
 FROM cypress/base:10
-
-# Optionally pass proxy information to get internet connectivity within npm ci 
-# postinstall hooks when running behind corparate proxies.
-ARG http_proxy 
-ARG https_proxy
-ARG no_proxy
-
 WORKDIR /app
 
 # dependencies will be installed only if the package files change


### PR DESCRIPTION
There was a bug with this PR where the Apache container was actually based on the Cypress image

This PR reverts that change, as well as the "corporate proxy" functionality, which seems out of place and beyond the scope of this sample project.

I have a feeling CI tests were passing erroneously for this project as they were timing out instead of being a correct exit 0.