### PR TITLE
Fix dependency issues and errors.

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/base:14
+FROM cypress/base:18.6.0
 WORKDIR /app
 
 # dependencies will be installed only if the package files change

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM httpd:2.4
+FROM httpd:latest
 # prevent error message
 #  AH00558: apache2: Could not reliably determine
 #  the server's fully qualified domain name"


### PR DESCRIPTION
Update the Dockerfiles in the e2e and webapp folders to the current latest versions of cypress/base and httpd.

Suggestion: Update the latest tag on the cypress/base docker hub in order to prevent the need to update the e2e Dockerfile in the future.